### PR TITLE
Prevent max stats from being given in every claimed ball

### DIFF
--- a/not-a-package/daily.py
+++ b/not-a-package/daily.py
@@ -91,8 +91,8 @@ TIMEZONE_SETTING = timezone(timedelta(hours=8)) # Timezone configuration - chang
                 ball=ball,
                 player=player,
                 special=special,
-                attack_bonus=random.randint(settings.max_attack_bonus, settings.max_attack_bonus),
-                health_bonus=random.randint(settings.max_health_bonus, settings.max_health_bonus),
+                attack_bonus=random.randint(-settings.max_attack_bonus, +settings.max_attack_bonus),
+                health_bonus=random.randint(-settings.max_health_bonus, +settings.max_health_bonus),
             )
             
             self.daily_claims[user_id] = now


### PR DESCRIPTION
Fixes the bug of max stats being given in every ball (+20/+20 or +100/+100 for example)

This has been tested on my bot.